### PR TITLE
Move attribute to Form_Element

### DIFF
--- a/usr/local/www/classes/Form.class.php
+++ b/usr/local/www/classes/Form.class.php
@@ -37,15 +37,18 @@ class Form extends Form_Element
 	protected $_sections = array();
 	protected $_global = array();
 	protected $_labelWidth = 2;
-	// Empty is interpreted by all browsers to submit to the current URI
-	protected $_action;
 
 	public function __construct()
 	{
+		$this->addClass('form-horizontal');
+		$this->setAttribute('method', 'post');
+
 		$this->addGlobal(new Form_Button(
 			'save',
 			'Save'
 		));
+
+	return $this;
 	}
 
 	public function add(Form_Section $section)
@@ -66,7 +69,9 @@ class Form extends Form_Element
 
 	public function setAction($uri)
 	{
-		$this->_action = $uri;
+		$this->setAttribute('action', $uri);
+
+		return $this;
 	}
 
 	public function getLabelWidth()
@@ -100,7 +105,7 @@ class Form extends Form_Element
 		$html .= implode('', $this->_global);
 
 		return <<<EOT
-	<form class="form-horizontal" action="{$this->_action}" method="post">
+	<form {$this->getHtmlAttribute()}>
 		{$html}
 	</form>
 EOT;

--- a/usr/local/www/classes/Form/Button.class.php
+++ b/usr/local/www/classes/Form/Button.class.php
@@ -28,19 +28,14 @@
 */
 class Form_Button extends Form_Input
 {
-	protected $_link;
-
 	public function __construct($name, $title, $link = null)
 	{
 		// If we have a link; we're actually an <a class='btn'>
-		if (isset($link))
-		{
-			$this->_link = $link;
+		if (isset($link)) {
+			$this->setAttribute('href', htmlspecialchars($link));
 			$this->addClass('btn-default');
 			$type = null;
-		}
-		else
-		{
+		} else {
 			$this->addClass('btn-primary');
 			$this->setAttribute('value', $title);
 			$type = 'submit';
@@ -53,17 +48,14 @@ class Form_Button extends Form_Input
 
 	protected function _getInput()
 	{
-		if (!isset($this->_link))
+		if (empty($this->getAttribute('href'))) {
 			return parent::_getInput();
+		}
 
 		$element = preg_replace('~^<input(.*)/>$~', 'a\1', parent::_getInput());
-		$link = htmlspecialchars($this->_link);
-		$title = htmlspecialchars($this->_title);
 
 		return <<<EOT
-	<{$element} href="{$link}">
-		{$title}
-	</a>
+	<{$element}>{$this->_title}</a>
 EOT;
 	}
 }

--- a/usr/local/www/classes/Form/Checkbox.class.php
+++ b/usr/local/www/classes/Form/Checkbox.class.php
@@ -39,8 +39,9 @@ class Form_Checkbox extends Form_Input
 		$this->removeClass('form-control');
 		$this->addColumnClass('checkbox');
 
-		if ($checked)
-			$this->_attributes['checked'] = 'checked';
+		if ($checked) {
+			$this->setAttribute('checked', 'checked');
+		}
 	}
 
 	public function displayAsRadio()

--- a/usr/local/www/classes/Form/Element.class.php
+++ b/usr/local/www/classes/Form/Element.class.php
@@ -29,13 +29,13 @@
 
 class Form_Element
 {
-	protected $_classes = array();
+	protected $_attributes = array('class' => array());
 	protected $_parent;
 
 	public function addClass()
 	{
 		foreach (func_get_args() as $class) {
-			$this->_classes[$class] = true;
+			$this->_attributes['class'][$class] = true;
 		}
 
 		return $this;
@@ -43,22 +43,51 @@ class Form_Element
 
 	public function removeClass($class)
 	{
-		unset($this->_classes[$class]);
+		unset($this->_attributes['class'][$class]);
 
 		return $this;
 	}
 
-	public function getHtmlClass($wrapped = true)
+	public function getClasses()
 	{
-		if (empty($this->_classes))
-				return '';
+		return implode(' ', array_keys($this->getAttribute('class')));
+	}
 
-		$list = implode(' ', array_keys($this->_classes));
+	public function setAttribute($key, $value = null)
+	{
+		$this->_attributes[$key] = $value;
 
-		if (!$wrapped)
-			return $list;
+		return $this;
+	}
 
-		return 'class="'. $list .'"';
+	public function getAttribute($name)
+	{
+		return $this->_attributes[$name];
+	}
+
+	public function removeAttribute($name)
+	{
+		unset($this->_attributes[$name]);
+
+		return $this;
+	}
+
+	public function getHtmlAttribute()
+	{
+		/* Will overwright _attributes['class'] with string Therefore you cannot 
+		 * delete or add classes once getHtmlAttribute() has been called. */
+		if (empty($this->_attributes['class'])) {
+			$this->removeAttribute('class');
+		} else {
+			$this->_attributes['class'] = $this->getClasses();
+		}
+
+		$attributes = '';
+		foreach ($this->_attributes as $key => $value) {
+			$attributes .= ' ' . $key . (isset($value) ? '="' . htmlspecialchars($value) . '"' : '');
+		}
+
+		return $attributes;
 	}
 
 	protected function _setParent(Form_Element $parent)

--- a/usr/local/www/classes/Form/Group.class.php
+++ b/usr/local/www/classes/Form/Group.class.php
@@ -90,16 +90,15 @@ class Form_Group extends Form_Element
 		foreach ($missingWidth as $input)
 			$input->setWidth($spaceLeft / count($missingWidth));
 
-		$target = $this->_labelTarget->getName();
+		$target = $this->_labelTarget->getAttribute('name');
 		$inputs = implode('', $this->_inputs);
 		$help = isset($this->_help) ? '<div class="col-sm-'. (12 - $this->getLabelWidth()) .' col-sm-offset-'. $this->getLabelWidth() .'"><span class="help-block">'. gettext($this->_help). '</span></div>' : '';
 
 		return <<<EOT
-	<div {$this->getHtmlClass()}>
+	<div {$this->getHtmlAttribute()}>
 		<label for="{$target}" class="col-sm-{$this->getLabelWidth()} control-label">
 			{$this->_title}
 		</label>
-
 		{$inputs}
 		{$help}
 	</div>

--- a/usr/local/www/classes/Form/Input.class.php
+++ b/usr/local/www/classes/Form/Input.class.php
@@ -29,7 +29,6 @@
 class Form_Input extends Form_Element
 {
 	protected $_title;
-	protected $_attributes = array();
 	protected $_help;
 	protected $_helpParams = array();
 	protected $_columnWidth;
@@ -37,16 +36,22 @@ class Form_Input extends Form_Element
 
 	public function __construct($name, $title, $type = 'text', $value = null, array $attributes = array())
 	{
-		$this->_attributes['name'] = $name;
-		$this->_attributes['id'] = $name;
-		$this->_title = $title;
+		$this->setAttribute('name', $name);
+		$this->setAttribute('id', $name);
+		$this->_title = htmlspecialchars($title);
 		$this->addClass('form-control');
 
-		if (isset($type))
-			$this->_attributes['type'] = $type;
+		if (isset($type)) {
+			$this->setAttribute('type', $type);
+		}
 
-		if (isset($value))
-			$this->_attributes['value'] = $value;
+		if (isset($value)) {
+			$this->setAttribute('value', $value);
+		}
+
+		foreach($attributes as $name => $value) {
+			$this->setAttribute($name, $value);
+		}
 
 		return $this;
 	}
@@ -54,11 +59,6 @@ class Form_Input extends Form_Element
 	public function getTitle()
 	{
 		return $this->_title;
-	}
-
-	public function getName()
-	{
-		return $this->_attributes['name'];
 	}
 
 	public function setHelp($help, array $params = array())
@@ -76,21 +76,15 @@ class Form_Input extends Form_Element
 
 	public function setWidth($size)
 	{
-		if ($size < 1 || $size > 12)
+		if ($size < 1 || $size > 12) {
 			throw new Exception('Incorrect size, pass a number between 1 and 12');
+		}
 
 		$this->removeColumnClass('col-sm-'. $this->_columnWidth);
 
 		$this->_columnWidth = (int)$size;
 
 		$this->addColumnClass('col-sm-'. $this->_columnWidth);
-
-		return $this;
-	}
-
-	public function setAttribute($key, $value = null)
-	{
-		$this->_attributes[ $key ] = $value;
 
 		return $this;
 	}
@@ -119,22 +113,14 @@ class Form_Input extends Form_Element
 
 	protected function _getInput()
 	{
-		$html = '<input';
-
-		foreach ($this->_attributes as $key => $value)
-			$html .= ' '.$key. (isset($value) ? '="'. htmlspecialchars($value).'"' : '');
-
-		return $html .'/>';
+		return "<input{$this->getHtmlAttribute()}/>";
 	}
 
 	public function __toString()
 	{
-		$this->_attributes['class'] = $this->getHtmlClass(false);
-
 		$input = $this->_getInput();
 
-		if (isset($this->_help))
-		{
+		if (isset($this->_help)) {
 			$help = gettext($this->_help);
 
 			if (!empty($this->_helpParams))
@@ -153,7 +139,6 @@ class Form_Input extends Form_Element
 		return <<<EOT
 	<div {$this->getColumnHtmlClass()}>
 		{$input}
-
 		{$help}
 	</div>
 EOT;

--- a/usr/local/www/classes/Form/Section.class.php
+++ b/usr/local/www/classes/Form/Section.class.php
@@ -70,12 +70,13 @@ class Form_Section extends Form_Element
 		$body = implode('', $this->_groups);
 
 		return <<<EOT
-	<div {$this->getHtmlClass()}>
+	<div {$this->getHtmlAttribute()}>
 		<div class="panel-heading">
 			<h2 class="panel-title">{$title}</h2>
 		</div>
-
-		<div class="panel-body">{$body}</div>
+		<div class="panel-body">
+			{$body}
+		</div>
 	</div>
 EOT;
 	}

--- a/usr/local/www/classes/Form/Select.class.php
+++ b/usr/local/www/classes/Form/Select.class.php
@@ -34,13 +34,12 @@ class Form_Select extends Form_Input
 
 	public function __construct($name, $title, $value, array $values, $allowMultiple = false)
 	{
-		parent::__construct($name, $title, null);
-
-		if ($allowMultiple)
-		{
-			$this->_attributes['multiple'] = 'multiple';
-			$this->_attributes['name'] .= '[]';
+		if ($allowMultiple) {
+			$this->setAttribute('multiple', 'multiple');
+			$name = $name . '[]';
 		}
+
+		parent::__construct($name, $title, null);
 
 		$this->_value = $value;
 		$this->_values = $values;
@@ -51,13 +50,8 @@ class Form_Select extends Form_Input
 		$element = preg_replace('~^<input(.*)/>$~', 'select\1', parent::_getInput());
 
 		$options = '';
-		foreach ($this->_values as $value => $name)
-		{
-			if (isset($this->_attributes['multiple']))
-				$selected = in_array($value, (array)$this->_value);
-			else
-				$selected = ($this->_value == $value);
-
+		foreach ($this->_values as $value => $name) {
+			$selected = (is_array($this->_value) && array_key_exists($value, $this->_value) || $this->_value == $value);
 			$options .= '<option value="'. htmlspecialchars($value) .'"'.($selected ? ' selected' : '').'>'. gettext($name) .'</option>';
 		}
 


### PR DESCRIPTION
- Removes redundant code
- Adds the ability to remove attributes
- Can now add attributes to Form
- getHtmlAttribute() returns all attributes including class

Conflicts:
    usr/local/www/classes/Form/Button.class.php
    usr/local/www/classes/Form/Select.class.php

Same as #32 just new source branch.
