### PR TITLE
diag_pf_info proposal

### DIFF
--- a/usr/local/www/diag_pf_info.php
+++ b/usr/local/www/diag_pf_info.php
@@ -65,28 +65,13 @@ include("head.inc");
 
 if ($input_errors)
 	print_input_errors($input_errors);
-
-require('classes/Form.class.php');
-$form = new Form(false);
-$form->addGlobal(new Form_Input(
-	'getactivity',
-	null,
-	'hidden',
-	'yes'
-));
-$section = new Form_Section('Auto update page');
-
-$section->addInput(new Form_Checkbox(
-	'refresh',
-	'Refresh',
-	'Automatically refresh the output below',
-	true
-));
-
-$form->add($section);
-print $form;
-
 ?>
+
+<form class="form-horizontal" method="post" action="">
+    <input class="form-control" name="getactivity" id="getactivity" type="hidden" value="yes"/>
+    <label><input name="refresh" id="refresh" type="checkbox" value="yes" checked="checked"/>&nbsp;Auto refresh</label>
+</form>	
+	
 <script>
 	function getpfinfo() {
 		if (!$('#refresh').is(':checked'))
@@ -116,4 +101,5 @@ print $form;
 	</div>
 </div>
 
-<?php include("foot.inc");
+<?php include("foot.inc"); ?>
+


### PR DESCRIPTION
This file currently contains:

$form = new Form(false);

which creates a fatal error because Form() takes a Form_Button, not a
boolean. I believe it should be:

$form = new Form(new Form_Button(
'',
''
));

In my opinion, however, a whole panel for one checkbox is a waste of
valuable screen space, particularly since the original pfSense page did
not have that checkbox.

Please consider this version with a minimal checkbox.
