### PR TITLE
diag_logs_settings - Corrected

### DIFF
--- a/usr/local/www/diag_logs_settings.php
+++ b/usr/local/www/diag_logs_settings.php
@@ -215,7 +215,6 @@ $tab_array[] = array(gettext("OpenVPN"), false, "diag_logs_openvpn.php");
 $tab_array[] = array(gettext("NTP"), false, "diag_logs_ntpd.php");
 $tab_array[] = array(gettext("Settings"), true, "diag_logs_settings.php");
 display_top_tabs($tab_array);
-
 require('classes/Form.class.php');
 
 $form = new Form(new Form_Button(
@@ -223,6 +222,7 @@ $form = new Form(new Form_Button(
 	gettext("Save")
 ));
 
+// General logging section ------------------------------------------------
 $section = new Form_Section('General Logging Options');
 
 $section->addInput(new Form_Checkbox(
@@ -312,24 +312,29 @@ $section->addInput(new Form_Checkbox(
 $section->addInput(new Form_Button(
 	'resetlogs',
 	'Reset Log Files'
-))->addClass('btn-danger btn-xs')->setHelp('Clears all local log files and reinitializes them as empty logs. This also restarts the DHCP daemon. Use the Save button first if you have made any setting changes.');
+))->addClass("btn-danger btn-xs")->setHelp('Clears all local log files and reinitializes them as empty logs. This also restarts the DHCP daemon. Use the Save button first if you have made any setting changes.');
 
 $form->add($section);
-$section = new Form_Section('Remote Logging Options');
-$section->addClass('toggle-remote');
 
-$section->addInput(new Form_Checkbox(
-	'enable',
-	'Enable Remote Logging',
-	'Send log messages to remote syslog server',
-	$pconfig['enable']
-))->toggles('.toggle-remote .panel-body .form-group:not(:first-child)');
+// Remote logging section ------------------------------------------------
+$section = new Form_Section('Remote Logging Options');
+
+$sourceips = get_possible_traffic_source_addresses(false);
+
+$selected = "";
+
+foreach ($sourceips as $sa) {
+	$rllist[$sa['value']] = $sa['name'];
+
+	if (!link_interface_to_bridge($sa['value']) && ($sa['value'] == $pconfig['sourceip']))
+		$selected = $sa['value'];
+}
 
 $section->addInput(new Form_Select(
 	'sourceip',
 	'Source Address',
-	link_interface_to_bridge($pconfig['sourceip']) ? null : $pconfig['sourceip'],
-	get_possible_traffic_source_addresses(false)
+	$selected,
+	$rllist
 ))->setHelp($remoteloghelp);
 
 $section->addInput(new Form_Select(
@@ -339,8 +344,19 @@ $section->addInput(new Form_Select(
 	array('ipv4' => 'IPv4', 'ipv6' => 'IPv6')
 ))->setHelp('This option is only used when a non-default address is chosen as the source above. This option only expresses a preference; If an IP address of the selected type is not found on the chosen interface, the other type will be tried.');
 
+$section->addInput(new Form_Checkbox(
+	'enable',
+	'Enable Remote Logging',
+	'Send log messages to remote syslog server',
+	$pconfig['enable']
+))->toggles('.toggle-remote');
+
 // Group colapses/appears based on 'enable' checkbox above
 $group = new Form_Group('Remote log servers');
+$group->addClass('toggle-remote', 'collapse');
+
+if ($pconfig['enable'])
+	$group->addClass('in');
 
 $group->add(new Form_Input(
 	'remoteserver',
@@ -368,70 +384,73 @@ $group->add(new Form_Input(
 
 $section->add($group);
 
-$group = new Form_Group('Remote Syslog Contents');
+$group = new Form_Group('');
+$group->addClass('toggle-remote', 'collapse');
+
+if ($pconfig['enable'])
+	$group->addClass('in');
+
 $group->add(new Form_Checkbox(
 	'system',
-	null,
+	'',
 	'System Events',
 	$pconfig['system']
 ));
 
 $group->add(new Form_Checkbox(
 	'filter',
-	null,
+	'',
 	'Firewall Events',
 	$pconfig['filter']
 ));
 
 $group->add(new Form_Checkbox(
 	'dhcp',
-	null,
+	'',
 	'DHCP service events',
 	$pconfig['dhcp']
 ));
 
 $group->add(new Form_Checkbox(
 	'portalauth',
-	null,
+	'',
 	'Portal Auth events',
 	$pconfig['portalauth']
 ));
 
 $group->add(new Form_Checkbox(
 	'vpn',
-	null,
+	'',
 	'VPN (PPTP, IPsec, OpenVPN) events',
 	$pconfig['vpn']
 ));
 
 $group->add(new Form_Checkbox(
 	'apinger',
-	null,
+	'',
 	'Gateway Monitor events',
 	$pconfig['apinger']
 ));
 
 $group->add(new Form_Checkbox(
 	'relayd',
-	null,
+	'',
 	'Server Load Balancer events',
 	$pconfig['relayd']
 ));
 
 $group->add(new Form_Checkbox(
 	'hostapd',
-	null,
+	'',
 	'Wireless events',
 	$pconfig['hostapd']
 ));
 
-$group->setHelp('syslog sends UDP datagrams to port 514 on the specified remote '.
-	'syslog server, unless another port is specified. Be sure to set syslogd on '.
-	'the remote server to accept syslog messages from pfSense.');
+$group->setHelp('<strong>Note</strong>' . 'syslog sends UDP datagrams to port 514 on the specified remote syslog server, unless another port is specified. Be sure to set syslogd on the remote server to accept syslog messages frompfSense.');
 
 $section->add($group);
 
 $form->add($section);
 print $form;
 
-include("foot.inc");
+include("foot.inc"); ?>


### PR DESCRIPTION
There were two issues in this change:

1)
On line 331 Form_Select had wrong argument type causing gettext errors
in Form.class

2)
Missing:

if ($pconfig['enable'])
$group->addClass('in');

Caused incorrect collapse/in state on page load.
